### PR TITLE
Build against `vector-0.13`

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -30,7 +30,7 @@ Library
         primitive                   < 0.8 ,
         text         >= 0.11.2.0 && < 2.1 ,
         transformers >= 0.2.0.0  && < 0.7 ,
-        vector       >= 0.7      && < 0.13,
+        vector       >= 0.7      && < 0.14,
         containers   >= 0.5.0.0  && < 0.7 ,
         unordered-containers        < 0.3 ,
         hashable                    < 1.5 ,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/6624