### PR TITLE
Require profunctors >= 3.2

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -35,7 +35,7 @@ Library
         unordered-containers        < 0.3 ,
         hashable                    < 1.5 ,
         contravariant               < 1.6 ,
-        profunctors                 < 5.7 ,
+        profunctors  >= 3.2      && < 5.7 ,
         semigroupoids >= 1.0     && < 5.4 ,
         comonad      >= 4.0      && < 6
     if impl(ghc < 8.0)


### PR DESCRIPTION
`Choice` is not available from `Data.Profunctor` before `profunctors-3.2`.

As a Hackage trustee I made appropriate revisions for `foldl >= 1.4.5`.