### PR TITLE
Cosieve and Costrong instances

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -35,7 +35,7 @@ Library
         unordered-containers        < 0.3 ,
         hashable                    < 1.5 ,
         contravariant               < 1.6 ,
-        profunctors  >= 3.2      && < 5.7 ,
+        profunctors  >= 4.3.2    && < 5.7 ,
         semigroupoids >= 1.0     && < 6.1 ,
         comonad      >= 4.0      && < 6
     if impl(ghc < 8.0)

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -254,7 +254,8 @@ instance Cosieve Fold [] where
 instance Costrong Fold where
     unfirst p = fmap f list
       where
-        f fa = b where (b, d) = fold p ((\a -> (a, d)) <$> fa)
+        f as = b
+          where (b, d) = fold p [ (a, d) | a <- as ]
     {-# INLINE unfirst #-}
 
 instance Comonad (Fold a) where

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -41,6 +41,7 @@
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE Trustworthy               #-}
@@ -164,6 +165,7 @@ import Data.Monoid hiding ((<>))
 import Data.Semigroupoid (Semigroupoid)
 import Data.Functor.Extend (Extend(..))
 import Data.Profunctor
+import Data.Profunctor.Sieve
 import Data.Sequence ((|>))
 import Data.Vector.Generic (Vector, Mutable)
 import Data.Vector.Generic.Mutable (MVector)
@@ -242,8 +244,18 @@ instance Profunctor Fold where
     rmap = fmap
 
 instance Choice Fold where
-  right' (Fold step begin done) = Fold (liftA2 step) (Right begin) (fmap done)
-  {-# INLINE right' #-}
+    right' (Fold step begin done) = Fold (liftA2 step) (Right begin) (fmap done)
+    {-# INLINE right' #-}
+
+instance Cosieve Fold [] where
+    cosieve = fold
+    {-# INLINE cosieve #-}
+
+instance Costrong Fold where
+    unfirst p = fmap f list
+      where
+        f fa = b where (b, d) = fold p ((\a -> (a, d)) <$> fa)
+    {-# INLINE unfirst #-}
 
 instance Comonad (Fold a) where
     extract (Fold _ begin done) = done begin

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-7.14
+resolver: lts-18.0


### PR DESCRIPTION
This is a PR which adds the instances, as mentioned in #197.

I decided not to add the `Corepresentable` instance, since it does rely on `cosieve . cotabulate` not being passed an infinite list.
Thus the `Costrong` instance simply inlines `unfirstCorep` as stated previously.

I also bumped the lts version to `lts-18.0`, since that is the earliest version which satisfies the `random >= 1.2.0` constraint (which also happens to satisfy the profunctors constraint).