### PR TITLE
Update dependencies

### DIFF
--- a/foldl.cabal
+++ b/foldl.cabal
@@ -25,13 +25,13 @@ Library
     HS-Source-Dirs: src
     Build-Depends:
         base         >= 4.11.0.0 && < 5   ,
-        bytestring   >= 0.9.2.1  && < 0.12,
+        bytestring   >= 0.9.2.1  && < 0.13,
         random       >= 1.2      && < 1.3 ,
-        primitive                   < 0.9 ,
-        text         >= 0.11.2.0 && < 2.1 ,
+        primitive                   < 0.10,
+        text         >= 0.11.2.0 && < 2.2 ,
         transformers >= 0.2.0.0  && < 0.7 ,
         vector       >= 0.7      && < 0.14,
-        containers   >= 0.5.0.0  && < 0.7 ,
+        containers   >= 0.5.0.0  && < 0.8 ,
         unordered-containers        < 0.3 ,
         hashable                    < 1.5 ,
         contravariant               < 1.6 ,


### PR DESCRIPTION
This is required for to to build it with `ghc-9.8` as a component of a rather large project.

The tests fail, but they also fail with `ghc-9.6` before I bumped the dependencies, so this it not due to the deps.

There are also a number of compiler warnings.

I would appreciate a fixed version on Hackage and since this is just a dependency update that could be achieved by a metadata edit.