### PR TITLE
Add Fold1 pattern synonym & utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add [Fold1 utilities](): `purely`, `purely_`, `premap`
+- Add [Fold1 utilities](): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`
 - Add pattern synonym `Fold1_` that makes the initial, step and extraction functions explicit.
 
 1.4.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add [Fold1 utilities](): `purely`, `purely_`
+- Add [Fold1 utilities](): `purely`, `purely_`, `premap`
 - Add pattern synonym `Fold1_` that makes the initial, step and extraction functions explicit.
 
 1.4.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+- Add pattern synonym `Fold1_` that makes the initial, step and extraction functions explicit.
+
 1.4.16
 
-- Add [`Control.Foldl.postmapM`]
+- Add [`Control.Foldl.postmapM`](https://github.com/Gabriella439/foldl/pull/205)
 
 1.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add [Fold1 utilities](): `purely`, `purely_`
 - Add pattern synonym `Fold1_` that makes the initial, step and extraction functions explicit.
 
 1.4.16

--- a/bench/Foldl.hs
+++ b/bench/Foldl.hs
@@ -3,11 +3,16 @@
 module Main (main) where
 
 import Control.Foldl hiding (map)
+import qualified Control.Foldl.NonEmpty as Foldl1
 import Criterion.Main
 import qualified Data.List
 import Prelude hiding (length, sum)
 import qualified Prelude
 import qualified Data.Foldable as Foldable
+import Data.Functor.Contravariant (Contravariant(..))
+import Data.Profunctor (Profunctor(..))
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
 
 main :: IO ()
 main = defaultMain
@@ -50,8 +55,26 @@ main = defaultMain
                 nf sumAndLength_foldl
             ]
         ]
+  , env (return $ 1 :| [2..10000 :: Int]) $ \ns ->
+      bgroup "1 :| [2..10000 :: Int]"
+        [ bgroup "handles" $ map ($ ns)
+            [ bench "fold (handles (to succ) list)" .
+                nf (fold (handles (to succ) list))
+            , bench "foldM (handlesM (to succ) (generalize list))" .
+                nfIO . foldM (handlesM (to succ) (generalize list))
+            , bench "NonEmpty.map succ" .
+                nf (NonEmpty.map succ)
+            , bench "Foldl1.fold1 (Foldl1.handles (to succ) (Foldl1.fromFold list))" .
+                nf (Foldl1.fold1 (Foldl1.handles (to succ) (Foldl1.fromFold list)))
+            ]
+        ]
   ]
 
+
+-- local definition to avoid importing Control.Lens.Getter.to
+to :: (Profunctor p, Contravariant f) => (s -> a) -> p a (f a) -> p s (f s)
+to k = dimap k (contramap k)
+{-# INLINE to #-}
 
 sumAndLength :: Num a => [a] -> (a, Int)
 sumAndLength xs = (Prelude.sum xs, Prelude.length xs)

--- a/foldl.cabal
+++ b/foldl.cabal
@@ -62,7 +62,8 @@ Benchmark Foldl
     Build-Depends:
         base,
         criterion,
-        foldl
+        foldl,
+        profunctors
     GHC-Options: -O2 -Wall -rtsopts -with-rtsopts=-T
     Default-Language: Haskell2010
 

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -92,11 +92,11 @@ module Control.Foldl (
     , Control.Foldl.mapM_
     , sink
 
-    -- * Generic Folds
+    -- ** Generic Folds
     , genericLength
     , genericIndex
 
-    -- * Container folds
+    -- ** Container Folds
     , list
     , revList
     , nub

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -209,6 +209,7 @@ import qualified Data.Semigroupoid
 {- $setup
 
 >>> import qualified Control.Foldl as Foldl
+>>> import Data.Functor.Apply (Apply(..))
 
 >>> _2 f (x, y) = fmap (\i -> (x, i)) (f y)
 
@@ -218,7 +219,7 @@ import qualified Data.Semigroupoid
 >>>         in Control.Foldl.Optics.prism Just maybeEither
 >>> :}
 
->>> both f (x, y) = (,) <$> f x <*> f y
+>>> both f (x, y) = (,) <$> f x <.> f y
 
 -}
 
@@ -1349,7 +1350,7 @@ type Handler a b =
 >>> fold (handles traverse sum) [[1..5],[6..10]]
 55
 
->>> fold (handles (traverse.traverse) sum) [[Nothing, Just 2, Just 7],[Just 13, Nothing, Just 20]]
+>>> fold (handles (traverse . traverse) sum) [[Nothing, Just 2, Just 7],[Just 13, Nothing, Just 20]]
 42
 
 >>> fold (handles (filtered even) sum) [1..10]
@@ -1382,7 +1383,7 @@ handles k (Fold step begin done) = Fold step' begin done
 
 > Foldl.foldOver f folder xs == Foldl.fold folder (xs^..f)
 
-> Foldl.foldOver (folded.f) folder == Foldl.fold (handles f folder)
+> Foldl.foldOver (folded . f) folder == Foldl.fold (handles f folder)
 
 > Foldl.foldOver folded == Foldl.fold
 
@@ -1443,7 +1444,7 @@ handlesM k (FoldM step begin done) = FoldM step' begin done
 
 {- | @(foldOverM f folder xs)@ folds all values from a Lens, Traversal, Prism or Fold monadically with the given folder
 
-> Foldl.foldOverM (folded.f) folder == Foldl.foldM (handlesM f folder)
+> Foldl.foldOverM (folded . f) folder == Foldl.foldM (handlesM f folder)
 
 > Foldl.foldOverM folded == Foldl.foldM
 

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -36,6 +37,10 @@ module Control.Foldl.NonEmpty (
 
     -- ** Non-empty Container Folds
     , nonEmpty
+
+    -- * Utilities
+    , purely
+    , purely_
     ) where
 
 import Control.Applicative (liftA2)
@@ -282,3 +287,13 @@ minimumBy cmp = Fold1 (\begin -> Fold min' begin id)
         GT -> y
         _  -> x
 {-# INLINABLE minimumBy #-}
+
+-- | Upgrade a fold to accept the 'Fold1' type
+purely :: (forall x . (a -> x) -> (x -> a -> x) -> (x -> b) -> r) -> Fold1 a b -> r
+purely f (Fold1_ begin step done) = f begin step done
+{-# INLINABLE purely #-}
+
+-- | Upgrade a more traditional fold to accept the `Fold1` type
+purely_ :: (forall x . (a -> x) -> (x -> a -> x) -> x) -> Fold1 a b -> b
+purely_ f (Fold1_ begin step done) = done (f begin step)
+{-# INLINABLE purely_ #-}

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP #-}
+
 {-| This module provides a `Fold1` type that is a \"non-empty\" analog of the
     `Fold` type, meaning that it requires at least one input element in order to
     produce a result
@@ -11,7 +16,7 @@
 
 module Control.Foldl.NonEmpty (
     -- * Fold Types
-      Fold1(..)
+      Fold1(.., Fold1_)
 
     -- * Folding
     , Control.Foldl.NonEmpty.fold1
@@ -47,6 +52,40 @@ import qualified Control.Foldl as Foldl
     element
 -}
 data Fold1 a b = Fold1 (a -> Fold a b)
+
+{-| @Fold1_@ is an alternative to the @Fold1@ constructor if you need to
+    explicitly work with an initial, step and extraction function.
+
+    @Fold1_@ is similar to the @Fold@ constructor, which also works with an
+    initial, step and extraction function. However, note that @Fold@ takes the
+    step function as the first argument and the initial accumulator as the
+    second argument, whereas @Fold1_@ takes them in swapped order:
+
+    @Fold1_ @ @ initial @ @ step @ @ extract@
+
+    While @Fold@ resembles 'Prelude.foldl', @Fold1_@ resembles
+    'Data.Foldable1.foldlMap1'.
+-}
+pattern Fold1_ :: forall a b. forall x. (a -> x) -> (x -> a -> x) -> (x -> b) -> Fold1 a b
+pattern Fold1_ begin step done <- (toFold_ -> (begin, step, done))
+  where Fold1_ begin step done = Fold1 $ \a -> Fold step (begin a) done
+#if __GLASGOW_HASKELL__ >= 902
+{-# INLINABLE Fold1_ #-}
+#endif
+{-# COMPLETE Fold1_ :: Fold1 #-}
+
+toFold_ :: Fold1 a b -> (a -> Fold a b, Fold a b -> a -> Fold a b, Fold a b -> b)
+toFold_ (Fold1 (f :: a -> Fold a b)) = (begin', step', done')
+  where
+    done' :: Fold a b -> b
+    done' (Fold _step begin done) = done begin
+
+    step' :: Fold a b -> a -> Fold a b
+    step' (Fold step begin done) a = Fold step (step begin a) done
+
+    begin' :: a -> Fold a b
+    begin' = f
+{-# INLINABLE toFold_ #-}
 
 instance Functor (Fold1 a) where
     fmap f (Fold1 k) = Fold1 (fmap (fmap f) k)

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -13,6 +13,16 @@
     which can make use of the non-empty input guarantee (e.g. `head`).  For
     all other utilities you can convert them from the equivalent `Fold` using
     `fromFold`.
+
+    Import this module qualified to avoid clashing with the Prelude:
+
+>>> import qualified Control.Foldl.NonEmpty as Foldl1
+
+    Use 'fold1' to apply a 'Fold1' to a non-empty list:
+
+>>> Foldl1.fold1 Foldl1.last (1 :| [2..10])
+10
+
 -}
 
 module Control.Foldl.NonEmpty (

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -9,7 +9,29 @@
     `fromFold`.
 -}
 
-module Control.Foldl.NonEmpty where
+module Control.Foldl.NonEmpty (
+    -- * Fold Types
+      Fold1(..)
+
+    -- * Folding
+    , Control.Foldl.NonEmpty.fold1
+
+    -- * Conversion between Fold and Fold1
+    , fromFold
+    , toFold
+
+    -- * Folds
+    , sconcat
+    , head
+    , last
+    , maximum
+    , maximumBy
+    , minimum
+    , minimumBy
+
+    -- ** Non-empty Container Folds
+    , nonEmpty
+    ) where
 
 import Control.Applicative (liftA2)
 import Control.Foldl (Fold(..))

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -1,4 +1,4 @@
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["-isrc", "src/Control/Foldl.hs", "src/Control/Scanl.hs"]
+main = doctest ["-isrc", "src/Control/Foldl/NonEmpty.hs", "src/Control/Foldl.hs", "src/Control/Scanl.hs"]


### PR DESCRIPTION
This change extends the API of `Control.Foldl.NonEmpty` by some of the exports suggested in #209:
- `Fold1_` pattern synonym
- `purely`
- `purely_`
- `premap`
- `handles`
- `foldOver`
- `folded1`

I created a naive [benchmark](https://github.com/Topsii/foldl/blob/335947515cd111ea687f6982d9bf48f615b5180b/bench/Foldl.hs#L59-L73) that compares the execution time of 
- `NonEmpty.map succ`
- variant that uses `Fold`
- variant that uses `FoldM`
- variant that uses the current definition `data Fold1 a b = forall x. Fold1 !(a -> x) !(x -> a -> x) !(x -> b)`  
  imported qualified as `Foldl1`
- variant that uses the alternative definition `data Fold1 a b = Fold1 (a -> Fold a b)` from #209
  imported qualified as `L1`

![image](https://github.com/user-attachments/assets/d626f85b-5108-4f9b-b8f6-bcf892d2ebe3)
Note that the y-axis uses a logarithmic scale.

In this benchmark the current definition of the `Fold1` data type clearly performs worse than the alternative definition of `Fold1`.
The alternative definition of `Fold1` performs similar to the `Fold(M)` variants.
Finally, the `Fold*` variants all perform worse than `NonEmpty.map succ`.

Personally, I favor changing the definition of the `Fold1` data type and turning the current definition into a pattern synonym. However, in #209 you mentioned you believe
> that for most functions the existing definition promotes the greatest code reuse.

Thus, I left the current definition unchanged and added the alternative definition as a pattern synonym.