### PR TITLE
Fix postmapM law by adding lifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add [`lifts`](https://github.com/Gabriella439/foldl/pull/214)
+
 1.4.17
 
 - Add [Fold1 utilities](): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -118,6 +118,7 @@ module Control.Foldl (
     , impurely_
     , generalize
     , simplify
+    , lifts
     , hoists
     , duplicateM
     , _Fold1
@@ -1163,6 +1164,14 @@ simplify (FoldM step begin done) = Fold step' begin' done'
 hoists :: (forall x . m x -> n x) -> FoldM m a b -> FoldM n a b
 hoists phi (FoldM step begin done) = FoldM (\a b -> phi (step a b)) (phi begin) (phi . done)
 {-# INLINABLE hoists #-}
+
+{- | Lift a monadic value to a 'FoldM';
+     works like 'Control.Monad.Trans.Class.lift'.
+
+> lifts . pure = pure
+-}
+lifts :: Monad m => m b -> FoldM m a b
+lifts mb = FoldM (\() _ -> pure ()) (pure ()) (\() -> mb)
 
 {-| Allows to continue feeding a 'FoldM' even after passing it to a function
 that closes it.

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -1239,11 +1239,11 @@ premapM f (FoldM step begin done) = FoldM step' begin done
 
 {-| @(postmapM f folder)@ returns a new 'FoldM' where f is applied to the final value.
 
-> postmapM return = id
+> postmapM pure = id
 >
 > postmapM (f >=> g) = postmapM g . postmapM f
 
-> postmapM k (pure r) = k r
+> postmapM k (pure r) = lifts (k r)
 -}
 postmapM :: Monad m => (a -> m r) -> FoldM m x a -> FoldM m x r
 postmapM f (FoldM step begin done) = FoldM step begin done'


### PR DESCRIPTION
Adds `lifts`, which is similar to `Control.Monad.Trans.Class.lift`. You could define a Monad instance for FoldM such that
```
lifts (m >>= f) = lifts m >>= (lifts . f)
```
```haskell
instance Monad (Fold a) where
  return = pure
  m >>= f = fold . f <$> m <*> list

instance Monad m => Monad (FoldM m a) where
  return = pure
  m >>= f = postmapM id $ foldM . f <$> m <*> generalize list
```
We already have `hoists`, which is similar to `Control.Monad.Morph.hoist`.
You can also define `embeds` and `squashes`, similar to `Control.Monad.Morph.embed` and `Control.Monad.Morph.squash`, respectively, satisfying (I believe)
```
embeds lifts = id

embeds f (lifts m) = f m
```
```haskell
embeds :: Monad n => (forall x. m x -> FoldM n a x) -> FoldM m a b -> FoldM n a b
embeds f fld = squashes $ hoists f fld

squashes :: (Monad m) => FoldM (FoldM m a) a b -> FoldM m a b
squashes (FoldM step begin done) = join $ FoldM step' begin' done'
  where
    step' fmax a = pure $ do
      x <- fmax
      step x a
    begin' = pure begin
    done' fmax = pure $ do
      x <- fmax
      done x
```

As I understand it, these Fold(M) Monad instances are not desirable because they do not stream in constant memory. Hence we only define `lifts` and use it to fix a law of `postmapM`.