### PR TITLE
Add more Fold1 instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add [`nest`](https://github.com/Gabriella439/foldl/pull/215) for `Fold1`
+- Add [`Choice`, `Closed`, `Cosieve`, `Extend`, `Semigroupoid`, `Category`, `Strong`, `Arrow` and `ArrowChoice`](https://github.com/Gabriella439/foldl/pull/215) instances for `Fold1`
 - Add [`Closed`](https://github.com/Gabriella439/foldl/pull/215) instance for `Fold`
 
 1.4.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add [`Closed`](https://github.com/Gabriella439/foldl/pull/215) instance for `Fold`
+
 1.4.17
 
 - Add [Fold1 utilities](https://github.com/Gabriella439/foldl/pull/212): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.4.17
 
-- Add [Fold1 utilities](): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`
-- Add pattern synonym `Fold1_` that makes the initial, step and extraction functions explicit.
+- Add [Fold1 utilities](https://github.com/Gabriella439/foldl/pull/212): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`
+- Add pattern synonym [`Fold1_`](https://github.com/Gabriella439/foldl/pull/212) that makes the initial, step and extraction functions explicit.
 
 1.4.16
 
@@ -15,7 +15,7 @@
 
 - Add [`Control.Foldl.NonEmpty.nonEmpty`](https://github.com/Gabriella439/foldl/pull/186)
 - Add [`Control.Foldl.NonEmpty.toFold`](https://github.com/Gabriella439/foldl/pull/191)
- - [Generalize `fold1` to work with `Foldable1`](https://github.com/Gabriella439/foldl/pull/185)
+- [Generalize `fold1` to work with `Foldable1`](https://github.com/Gabriella439/foldl/pull/185)
 
 1.4.13
 

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -219,7 +219,7 @@ import qualified Data.Semigroupoid
 >>>         in Control.Foldl.Optics.prism Just maybeEither
 >>> :}
 
->>> both f (x, y) = (,) <$> f x <.> f y
+>>> both f (x, y) = (,) <$> f x <*> f y
 
 -}
 

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -245,8 +245,12 @@ instance Profunctor Fold where
     rmap = fmap
 
 instance Choice Fold where
-    right' (Fold step begin done) = Fold (liftA2 step) (Right begin) (fmap done)
+    right' = nest
     {-# INLINE right' #-}
+
+instance Closed Fold where
+    closed = nest
+    {-# INLINE closed #-}
 
 instance Cosieve Fold [] where
     cosieve = fold

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -83,7 +83,7 @@ import qualified Control.Foldl as Foldl
 
 >>> _2 f (x, y) = fmap (\i -> (x, i)) (f y)
 
->>> both f (x, y) = (,) <$> f x <.> f y
+>>> both1 f (x, y) = (,) <$> f x <.> f y
 
 -}
 
@@ -404,7 +404,7 @@ handles k (Fold1_ begin step done) = Fold1_ begin' step' done
 
 {- | @(foldOver f folder xs)@ folds all values from a Lens, Traversal1 or Fold1 optic with the given folder
 
->>> foldOver (_2 . both) Foldl1.nonEmpty (1, (2, 3))
+>>> foldOver (_2 . both1) Foldl1.nonEmpty (1, (2, 3))
 2 :| [3]
 
 > Foldl1.foldOver f folder xs == Foldl1.fold1 folder (xs ^.. f)


### PR DESCRIPTION
I omitted `Costrong` and `ArrowLoop` instances for Fold1.  Fold already has a `Costrong` instance, but similar to the Monad instances mentioned in https://github.com/Gabriella439/foldl/pull/214#issue-2636762695 I wonder whether it is safer to omit them to ensure Fold1s are streaming constant memory.
```haskell
instance Costrong Fold1 where
    unfirst p = fmap f nonEmpty
      where
        f as = b
          where
            (b, d) = Control.Foldl.NonEmpty.fold1 p $ do
              a <- as
              pure (a, d)

instance ArrowLoop Fold1 where
    loop = unfirst
```

I also added `nest` for Fold1 and distinguished between both and both1 in the doctests.