### PR TITLE
Define stimes 0 for EndoM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [Define `stimes` from `EndoM`'s Semigroup instance for 0](https://github.com/Gabriella439/foldl/pull/217)
+
 1.4.17
 
 - Add [Fold1 utilities](): `purely`, `purely_`, `premap`, `handles`, `foldOver`, `folded1`

--- a/src/Control/Foldl.hs
+++ b/src/Control/Foldl.hs
@@ -162,6 +162,7 @@ import Data.Functor.Contravariant (Contravariant(..))
 import Data.HashMap.Strict (HashMap)
 import Data.Map.Strict (Map)
 import Data.Monoid hiding ((<>))
+import Data.Semigroup (Semigroup(stimes), stimesMonoid)
 import Data.Semigroupoid (Semigroupoid)
 import Data.Functor.Extend (Extend(..))
 import Data.Profunctor
@@ -1403,6 +1404,9 @@ newtype EndoM m a = EndoM { appEndoM :: a -> m a }
 instance Monad m => Semigroup (EndoM m a) where
     (EndoM f) <> (EndoM g) = EndoM (f <=< g)
     {-# INLINE (<>) #-}
+
+    stimes = stimesMonoid
+    {-# INLINE stimes #-}
 
 instance Monad m => Monoid (EndoM m a) where
     mempty = EndoM return


### PR DESCRIPTION
From the [docs ](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-Semigroup.html#v:stimesMonoid) of `stimesMonoid`:

> Unlike the default definition of [`stimes`](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-Semigroup.html#v:stimes), `stimesMonoid` is defined for 0 and so it should be preferred where possible.

