### PR TITLE
Remove unlawful ArrowChoice instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Remove [unlawful](https://github.com/Gabriella439/foldl/pull/96) `ArrowChoice` instance for `Fold1`
+
 1.4.18
 
 - Add [`lifts`](https://github.com/Gabriella439/foldl/pull/214)

--- a/src/Control/Foldl/NonEmpty.hs
+++ b/src/Control/Foldl/NonEmpty.hs
@@ -62,7 +62,7 @@ module Control.Foldl.NonEmpty (
     ) where
 
 import Control.Applicative (liftA2, Const(..))
-import Control.Arrow (Arrow (..), ArrowChoice (..))
+import Control.Arrow (Arrow (..))
 import Control.Category (Category ())
 import qualified Control.Category
 import Control.Comonad (Comonad(..))
@@ -205,10 +205,6 @@ instance Arrow Fold1 where
 
     first = first'
     {-# INLINE first #-}
-
-instance ArrowChoice Fold1 where
-    left = left'
-    {-# INLINE left #-}
 
 instance Num b => Num (Fold1 a b) where
     fromInteger = pure . fromInteger


### PR DESCRIPTION
```haskell
*> L1.fold1 (arr $ left id) (Right 10 :| [Left 200 :: Either Int Int])                     
Left 200
*> L1.fold1 (left $ arr id) (Right 10 :| [Left 200 :: Either Int Int]) 
Right 10
```
violates the [ArrowChoice law](https://hackage.haskell.org/package/base-4.18.1.0/docs/Control-Arrow.html#t:ArrowChoice) that `left (arr f) = arr (left f)`.

When I added this instance in #215 I was trusting that the [ArrowChoice instance](https://github.com/ekmett/folds/blob/f24f34e0ac82d0dac2051faef4aad2b4e85a0f15/src/Data/Fold/L1'.hs#L141-L152) that already existed in the [folds package](https://hackage.haskell.org/package/folds) was correct. I apologize for any inconvenience.